### PR TITLE
Adding missing dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
 	"require" : {
 	        "php" : ">=5.6",
 	        "thenetworg/oauth2-azure": "^2.0",
-	        "webklex/php-imap": "^2.5"
+	        "webklex/php-imap": "^2.5",
+	        "doctrine/dbal": "^2.12.1"
 	}
 }


### PR DESCRIPTION
Hi!
Trying to use the package I had a problem with a dependecy:

> 2022-04-20 18:49:16 | Error   | 2     | Uncaught Error: Class 'Doctrine\DBAL\Types\VarDateTimeImmutableType' not found in /var/www/html/itop/web/env-production/itop-o365-email-synchro-main/vendor/nesbot/carbon/src/Carbon/Doctrine/DateTimeImmutableType.php:12
> Stack trace:
> #0 /var/www/html/itop/web/lib/composer/ClassLoader.php(571): include()
> #1 /var/www/html/itop/web/lib/composer/ClassLoader.php(428): Composer\Autoload\includeFile()
> #2 [internal function]: Composer\Autoload\ClassLoader->loadClass()
> #3 /var/www/html/itop/web/env-production/itop-o365-email-synchro-main/vendor/nesbot/carbon/src/Carbon/Doctrine/CarbonImmutableType.php(11): spl_autoload_call()
> #4 /var/www/html/itop/web/lib/composer/ClassLoader.php(571): include('/var/www/html/i...')
> #5 /var/www/html/itop/web/lib/composer/ClassLoader.php(428): Composer\Autoload\includeFile()
> #6 [internal function]: Composer\Autoload\ClassLoader->loadClass()
> #7 [internal function]: spl_autoload_call()
> #8 /var/www/html/itop/web/application/utils.inc.php(2751): ReflectionClass->__construct()
> #9 /var/www/html | IssueLog |||
> array (
>   'type' => 1,
>   'file' => '/var/www/html/itop/web/env-production/itop-o365-email-synchro-main/vendor/nesbot/carbon/src/Carbon/Doctrine/DateTimeImmutableType.php',
>   'line' => 12,
> )

Adding the package to the composer.json file seems to be working propertly (or at least the backend portal loads :P)

Giorgio